### PR TITLE
inbrowser: inchrome but with the browser as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ children = [[2,3], [4,5], [6,7], [8,9], [1], [], [], [], []]
 t = D3Tree(children)
 
 inchrome(t)
+inbrowser(t, "firefox")
 ```
 By clicking on the nodes, you can expand it to look like the image at the top of the page.
 

--- a/src/D3Trees.jl
+++ b/src/D3Trees.jl
@@ -13,7 +13,8 @@ export
     D3TreeView,
 
     blink,
-    inchrome
+    inchrome,
+    inbrowser
 
 struct D3Tree
     children::Vector{Vector{Int}}

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -17,3 +17,15 @@ function inchrome(t::D3Tree)
         run(`google-chrome $fname`)
     end
 end
+
+function inbrowser(t::D3Tree, browsername::String)
+    fname = joinpath(mktempdir(), "tree.html")
+    open(fname, "w") do f
+        show(f, MIME("text/html"), t)
+    end
+    if Sys.iswindows()
+        run(`cmd /C start $browsername "$fname"`)
+    else
+        run(`$browsername $fname`)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,10 @@ t2 = D3Tree(children,
             svg_height=300
            )
 
-# inchrome(t)
+# inchrome(t1)
+# inbrowser(t1, "firefox")
 # inchrome(t2)
+# inbrowser(t2, "firefox")
 
 @show D3Trees.children(D3TreeNode(t1, 1))
 show(stdout, MIME("text/plain"), t1)


### PR DESCRIPTION
Adds a `inbrowser` function which is more generic than `inchrome`. Tested with firefox.