### PR TITLE
Add missing version number and compat entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,7 @@
 name = "D3Trees"
 uuid = "e3df1716-f71e-5df9-9e2d-98e193103c45"
 repo = "https://github.com/sisl/D3Trees.jl.git"
+version = "0.3.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -15,3 +16,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "NBInclude", "Base64"]
+
+[compat]
+julia = "1"


### PR DESCRIPTION
Added version number and compat entry for Julia 1. 

I ran into an issue when trying to locally dev this package through the package manager. The package manager reported that only version 0.0.0 is available. I think the missing version entry might be the reason?

I added the compat entry since AbstarctTrees.jl requires Julia 1 anyway.