### PR TITLE
Allows for expanding multiple levels with single click

### DIFF
--- a/js/tree_vis.js
+++ b/js/tree_vis.js
@@ -236,24 +236,48 @@ function showTree() {
       });
     }
 
-    // Toggle children on click, fetch from Julia server if necessary
-    function click(d) {
-        if (d.children) {
-            d._children = d.children;
-            d.children = null;
-            update(d, 750);
-        } else if (d._children) {
+    function hide_children(d){
+        d._children = d.children;
+        d.children = null;
+        update(d, 750);
+    }
+
+    async function display_children(d){
+        if (d._children) {
             d.children = d._children;
             d._children = null;
             update(d, 750);
         } else if(treeData.unexpanded_children.has(d.dataID)) {
-            fetchSubtree(d.dataID)
+            await fetchSubtree(d.dataID)
             .then(subtree => addSubTreeData(subtree))
             .then(() => initializeChildren(d, 1))
-            .then(() => update(d, 750))
+            .then(() => update(d, 750));
         } else {
             initializeChildren(d, 1);
             update(d, 750);
+        }
+    }
+
+    async function click(d) {
+        if (d.children) {
+            hide_children(d)
+        } else {
+            let depth = 1;
+            let expanding=null;
+            let to_expand=[d];
+            while(depth<=on_click_display_depth){
+                expanding=to_expand;
+                to_expand=[];
+                // console.log([depth, expanding.length])
+                while(expanding.length>0){
+                    let n = expanding.pop();
+                    await display_children(n)
+                    if(n.children && n.children.length>0){
+                        to_expand.push(...n.children);
+                    }
+                }
+                depth++;
+            }
         }
     }
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -58,6 +58,7 @@ function Base.show(f::IO, m::MIME"text/html", t::D3Tree)
                 var initExpand = $(get(t.options, :init_expand, 0));
                 var initDuration = $(get(t.options, :init_duration, 750));
                 var svgHeight = $(get(t.options, :svg_height, 600));
+                var on_click_display_depth = $(get(t.options, :on_click_display_depth, 1));
                 var tree_url = "$tree_url";
                 $js
                 })();


### PR DESCRIPTION
Adds tree parameter `on_click_display_depth` with default value `1` that allows for displaying more than one level of the tree with a single click.

For example, clicking a marked node expands whole subtree in circle: 
![image](https://user-images.githubusercontent.com/1710518/187938522-d8d96a66-302b-4ccf-b694-f0e4ce02d904.png)

Usage: `D3Tree(root, on_click_display_depth=2)`