### PR TITLE
Add support for VS-Code

### DIFF
--- a/css/tree_vis.css
+++ b/css/tree_vis.css
@@ -1,4 +1,21 @@
 
+:root {
+  --background-color: white;
+  --text-color: black;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: black;
+    --text-color: white;
+  }
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
 .node {
     cursor: pointer;
 }

--- a/src/show.jl
+++ b/src/show.jl
@@ -91,3 +91,9 @@ function Base.show(io::IO, m::MIME"text/plain", t::D3Tree)
     show(io, m, D3TreeView(D3TreeNode(t, 1), get(t.options, :init_expanded, false) ? typemax(Int) : 3))
 end
 Base.show(io::IO, m::MIME"text/plain", v::D3TreeView) = shownode(io, v.root, v.depth, "", "")
+
+# Support for Visual Studio Code plot pane:
+Base.showable(::MIME"juliavscode/html", ::D3Tree) = true
+function Base.show(@nospecialize(io::IO), ::MIME"juliavscode/html", @nospecialize(t::D3Tree))
+    show(io, MIME("text/html"), t)
+end


### PR DESCRIPTION
Makes D3Tree`s show in the VS-Code plot pane.

Demo (using a modified version of @mmikhasenko's expression-tree example):

![vscode-tree](https://github.com/user-attachments/assets/167bc99e-3304-46cb-b9ee-2cf961148a17)

Closes #31 .

* Adds a show method for `juliavscode/html`.
* Changes CSS to add a white/black background (depending on system prefs) and set the text color to black/white. Otherwise the black (default) node labels aren't visible with the VS-Code dark theme (default).

